### PR TITLE
Add CODEOWNERS for project

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# Lines starting with '#' are comments.
+# Each line is a file pattern followed by one or more owners.
+
+*                                    @RAnLabNL/devs


### PR DESCRIPTION
This PR adds [a `CODEOWNERS` file](https://docs.github.com/en/free-pro-team@latest/github/creating-cloning-and-archiving-repositories/about-code-owners) for the whole repository. This file (w/ the setting enabled) auto-adds reviewers for PRs.