### PR TITLE
UX improvements to editing flow

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -10,6 +10,7 @@ module.exports = {
     'plugin:react/recommended',
   ],
   rules: {
+    'array-bracket-spacing': ['error', 'never'],
     'comma-dangle': ['error', 'always-multiline'],
     'indent': ['error', 2, { 'SwitchCase': 1 }],
     'object-curly-spacing': ['error', 'always'],

--- a/components/base/AlertDialog.tsx
+++ b/components/base/AlertDialog.tsx
@@ -1,0 +1,69 @@
+import Dialog, { DialogProps } from '@material-ui/core/Dialog';
+import DialogActions from '@material-ui/core/DialogActions';
+import DialogContent from '@material-ui/core/DialogContent';
+import DialogContentText from '@material-ui/core/DialogContentText';
+import DialogTitle from '@material-ui/core/DialogTitle';
+import { MouseEvent, ReactElement, ReactNode } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import Button from './Button';
+
+type Props = {
+  cancelButton?: string;
+  confirmButton?: string;
+  content: ReactNode;
+  onCancel?: (e: MouseEvent) => void;
+  onClose: () => void;
+  onConfirm: (e: MouseEvent) => void;
+  open: DialogProps['open'];
+  title: ReactNode;
+};
+
+const AlertDialog = (props: Props): ReactElement => {
+  const { t } = useTranslation('components');
+  const {
+    cancelButton = t('alert-dialog-cancel'),
+    confirmButton = t('alert-dialog-confirm'),
+    content,
+    onCancel,
+    onClose,
+    onConfirm,
+    open,
+    title,
+  } = props;
+
+  const handleCancel = (e: MouseEvent) => {
+    if (onCancel) {
+      onCancel(e);
+    }
+    onClose();
+  };
+
+  return (
+    <Dialog
+      aria-describedby="alert-dialog-description"
+      aria-labelledby="alert-dialog-title"
+      onClose={onClose}
+      open={open}
+    >
+      <DialogTitle id="alert-dialog-title">
+        {title}
+      </DialogTitle>
+      <DialogContent>
+        <DialogContentText id="alert-dialog-description">
+          {content}
+        </DialogContentText>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={handleCancel} color="primary" variant="outlined">
+          {cancelButton}
+        </Button>
+        <Button onClick={onConfirm} color="primary" variant="contained" autoFocus>
+          {confirmButton}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default AlertDialog;

--- a/components/modules/businesses/BusinessesAddCell.tsx
+++ b/components/modules/businesses/BusinessesAddCell.tsx
@@ -25,7 +25,7 @@ const BusinessesAddCell = (props: Props): ReactElement => {
   // Used for id and name
   const id = `add-business-${field}`;
 
-  const [ value, setValue ] = useState<string | number>(defaultValue);
+  const [value, setValue] = useState<string | number>(defaultValue);
 
   /**
    * Handles changes of field values, sends value change to parent component.
@@ -108,7 +108,7 @@ const BusinessesAddCell = (props: Props): ReactElement => {
           label={label}
           name={id}
           type={field === 'employment' ? 'number' : 'text'}
-          value={value}
+          value={field === 'employment' ? undefined : value}
         />
       );
   }

--- a/components/modules/businesses/BusinessesTable.tsx
+++ b/components/modules/businesses/BusinessesTable.tsx
@@ -145,7 +145,7 @@ const BusinessesTable = (props: Props): ReactElement => {
 
   // TODO this needs to be fed in from API
   const editYearParams = {
-    values: [ 2019, 2020 ],
+    values: [2019, 2020],
   };
 
   // TODO this needs to be fed in from API
@@ -324,11 +324,11 @@ const BusinessesTable = (props: Props): ReactElement => {
     location: 'add',
   };
   const pinnedAddData = [defaultAddRow];
-  const [ removeSnackbarOpen, setRemoveSnackbarOpen ] = useState<boolean>(false);
-  const [ selectedRows, setSelectedRows] = useState<RowNode[]>([]);
+  const [removeSnackbarOpen, setRemoveSnackbarOpen] = useState<boolean>(false);
+  const [selectedRows, setSelectedRows] = useState<RowNode[]>([]);
 
-  const [ alertInfo, setAlertInfo ] = useState<AlertInfo>({});
-  const [ alertSnackbarOpen, setAlertSnackbarOpen ] = useState<boolean>(false);
+  const [alertInfo, setAlertInfo] = useState<AlertInfo>({});
+  const [alertSnackbarOpen, setAlertSnackbarOpen] = useState<boolean>(false);
 
   const handleAlertSnackbarClose = () => {
     setAlertSnackbarOpen(false);
@@ -504,6 +504,9 @@ const BusinessesTable = (props: Props): ReactElement => {
     () => {
       if (columnApi && editingEnabled) {
         columnApi.moveColumn('select', 0);
+      }
+      if (gridApi && !editingEnabled) {
+        gridApi.setRowData(originalData);
       }
     },
     [editingEnabled]

--- a/pages/businesses.tsx
+++ b/pages/businesses.tsx
@@ -25,6 +25,7 @@ import Button from '../components/base/Button';
 import DataSources from '../components/base/DataSourcesButton';
 import Typography from '../components/base/Typography';
 import RegionLayout from '../components/layout/region-layout/RegionLayout';
+import AlertDialog from '../components/base/AlertDialog';
 
 const useStyles = makeStyles(
   (theme) => {
@@ -117,24 +118,37 @@ const Businesses = (): ReactElement => {
     businessEditingEnabled,
     setBusinessEditingEnabled,
   ] = useState<boolean>(false);
+  const [
+    leaveEditsAlertOpen,
+    setLeaveEditsAlertOpen,
+  ] = useState<boolean>(false);
 
   const handleEditBusinesses = () => {
     setBusinessEditingEnabled(!businessEditingEnabled);
   };
 
   const handleCancelBusinessEdits = () => {
+    setLeaveEditsAlertOpen(true);
+  };
+
+  const handleLeaveEditsAlertClose = () => {
+    setLeaveEditsAlertOpen(false);
+  };
+
+  const handleLeaveEditsAlertConfirm = () => {
     setBusinessEditingEnabled(false);
+    setLeaveEditsAlertOpen(false);
   };
 
   // Transaction Record
 
-  const [ transactions, setTransactions ] = useState<UpdateTransaction>({
+  const [transactions, setTransactions] = useState<UpdateTransaction>({
     add: [],
     remove: [],
     update: [],
   });
 
-  const [ showConfirmation, setShowConfirmation ] = useState<boolean>(false);
+  const [showConfirmation, setShowConfirmation] = useState<boolean>(false);
 
   const handleSaveBusinesses = () => {
     setShowConfirmation(true);
@@ -142,6 +156,14 @@ const Businesses = (): ReactElement => {
 
   const handleCancelBusinessConfirmation = () => {
     setShowConfirmation(false);
+  };
+
+  const getSaveDisabled = (): boolean => {
+    return (
+      !transactions.add.length
+      && !transactions.remove.length
+      && !transactions.update.length
+    );
   };
 
   const handleConfirmBusinessUpdates = () => {
@@ -222,6 +244,7 @@ const Businesses = (): ReactElement => {
                       <Button
                         className={classes.buttonEdit}
                         color={'highlight'}
+                        disabled={getSaveDisabled()}
                         onClick={handleSaveBusinesses}
                         size="small"
                         startIcon={<SaveIcon fontSize="small" />}
@@ -303,6 +326,13 @@ const Businesses = (): ReactElement => {
           setTransactions={setTransactions}
           transactions={transactions}
           yearFilter={businessYearFilter}
+        />
+        <AlertDialog
+          content={t('businesses-leave-edits-content')}
+          onClose={handleLeaveEditsAlertClose}
+          onConfirm={handleLeaveEditsAlertConfirm}
+          open={leaveEditsAlertOpen}
+          title={t('businesses-leave-edits-title')}
         />
         {
           showConfirmation

--- a/translations/en/_components.json
+++ b/translations/en/_components.json
@@ -1,4 +1,6 @@
 {
+  "alert-dialog-cancel": "Cancel",
+  "alert-dialog-confirm": "OK",
   "businesses-action-cell-add": "Add",
   "businesses-bulk-remove-body": "Apply to selected (<1>{{count}}</1>):",
   "businesses-bulk-remove-button": "Remove",

--- a/translations/en/_pages.json
+++ b/translations/en/_pages.json
@@ -5,6 +5,8 @@
   "businesses-edit-cancel": "Cancel",
   "businesses-edit-save": "Save",
   "businesses-heading": "Businesses",
+  "businesses-leave-edits-content": "If you leave your edits all of your changes will be lost. Are you sure you want to leave?",
+  "businesses-leave-edits-title": "Are you sure you want to lose changes?",
   "index-link-region-dashboard": "Region Dashboard",
   "profile-edit-heading": "Edit Profile",
   "region-heading": "Region Homepage"


### PR DESCRIPTION
Closes #41 

- Prompt user to confirm and lose edit changes on "Cancel"
- Reset table data after cancelling
- Disable "Save" button until changes have been made