### PR TITLE
Added business update request table and pages

### DIFF
--- a/components/layout/NotificationsMenu.tsx
+++ b/components/layout/NotificationsMenu.tsx
@@ -5,6 +5,7 @@ import MenuItem from '@material-ui/core/MenuItem';
 import { makeStyles } from '@material-ui/core/styles';
 import NotificationsIcon from '@material-ui/icons/Notifications';
 import KeyboardArrowRightIcon from '@material-ui/icons/KeyboardArrowRight';
+import Link from 'next/link';
 import {
   MouseEvent,
   ReactElement,
@@ -208,12 +209,15 @@ const NotificationsMenu = (): ReactElement => {
           >
             {t('notifications-menu-heading')}
           </Typography>
-          <Button
-            size="small"
-            variant="outlined"
-          >
-            {t('notifications-menu-view-all')}
-          </Button>
+          <Link href="/updates">
+            <Button
+              component="a"
+              size="small"
+              variant="outlined"
+            >
+              {t('notifications-menu-view-all')}
+            </Button>
+          </Link>
         </div>
         <div className={classes.containerMenuItems}>
           {

--- a/components/layout/admin-layout/AdminLayout.tsx
+++ b/components/layout/admin-layout/AdminLayout.tsx
@@ -27,7 +27,12 @@ const drawerWidthMdEm = 22;
 
 const useStyles = makeStyles(
   (theme) => ({
-    root: {},
+    root: {
+      display: 'block',
+      [theme.breakpoints.up('sm')]: {
+        display: 'flex',
+      },
+    },
     appBar: {
       transition: theme.transitions.create(['margin', 'width'], {
         easing: theme.transitions.easing.sharp,

--- a/components/modules/updates/UpdateRequestsTable.tsx
+++ b/components/modules/updates/UpdateRequestsTable.tsx
@@ -1,0 +1,187 @@
+import classNames from 'classnames';
+import { makeStyles } from '@material-ui/core/styles';
+import Paper from '@material-ui/core/Paper';
+import Table from '@material-ui/core/Table';
+import TableBody from '@material-ui/core/TableBody';
+import TableCell from '@material-ui/core/TableCell';
+import TableContainer from '@material-ui/core/TableContainer';
+import TableHead from '@material-ui/core/TableHead';
+import TablePagination from '@material-ui/core/TablePagination';
+import TableRow from '@material-ui/core/TableRow';
+import {
+  MouseEvent,
+  ReactElement,
+  useState,
+} from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { fade } from '../../../styles/helpers/color';
+
+type Props = {
+  admin?: boolean,
+  dataSet: DataRow[],
+};
+
+const useStyles = makeStyles(
+  (theme) => ({
+    root: {},
+    tableCellHead: {
+      fontWeight: theme.typography.fontWeightBold,
+    },
+    tableRowBody: {
+      cursor: 'pointer',
+      '&:hover': {
+        background: fade(theme.palette.divider, 0.8),
+      },
+    },
+    tableCellBody: {},
+    tableCellBodyInProgress: {
+      background: fade(theme.palette.highlight.main, 0.9),
+    },
+    tableCellBodyApproved: {
+      background: fade(theme.palette.success.light, 0.8),
+    },
+    tableCellBodyDeclined: {
+      background: fade(theme.palette.error.light, 0.8),
+    },
+    tableCellBodyAmended: {
+      background: fade(theme.palette.warning.light, 0.8),
+    },
+  })
+);
+
+const UpdateRequestTable = ({ admin, dataSet }: Props): ReactElement => {
+  const { t } = useTranslation('components');
+  const classes = useStyles();
+  const [page, setPage] = useState<number>(0);
+  const rowsPerPage = admin ? 5 : 10;
+
+  const adminHeadings = [
+    'business-update-request-heading-region',
+    'business-update-request-heading-submitted-by',
+    'business-update-request-heading-date-submitted',
+    'business-update-request-heading-date-reviewed',
+    'business-update-request-heading-reviewer',
+    'business-update-request-heading-review-status',
+  ];
+
+  const regionHeadings = [
+    'business-update-request-heading-region',
+    'business-update-request-heading-date-submitted',
+    'business-update-request-heading-date-updated',
+    'business-update-request-heading-review-status',
+  ];
+
+  const headings = admin ? adminHeadings : regionHeadings;
+
+  const regionKeys = [
+    'region',
+    'dateSubmitted',
+    'dateUpdated',
+    'reviewStatus',
+  ];
+
+  const adminKeys = [
+    'region',
+    'submittedBy',
+    'dateSubmitted',
+    'dateReviewed',
+    'reviewer',
+    'reviewStatus',
+  ];
+
+  const dataKeys = admin ? adminKeys : regionKeys;
+
+  const handleRowClick = () => {
+    // TODO navigate to business update request on row click
+    console.log('click');
+  };
+
+  const handleChangePage = (
+    event: MouseEvent<HTMLButtonElement | MouseEvent> | null,
+    newPage: number
+  ) => {
+    setPage(newPage);
+  };
+
+  return (
+    <Paper className={classes.root}>
+      <TableContainer>
+        <Table aria-label="Business Update Requests">
+          <TableHead>
+            <TableRow>
+              {
+                headings.map(heading => (
+                  <TableCell
+                    className={classes.tableCellHead}
+                    key={heading}
+                  >
+                    {t(heading)}
+                  </TableCell>
+                ))
+              }
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {
+              dataSet
+                .slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage)
+                .map((row, index) => (
+                  <TableRow
+                    className={classes.tableRowBody}
+                    onClick={handleRowClick}
+                    key={index}
+                  >
+                    {
+                      dataKeys.map(key => (
+                        <TableCell
+                          className={classNames(
+                            classes.tableCellBody,
+                            {
+                              [classes.tableCellBodyInProgress]: row.reviewStatus === 'In Progress',
+                              [classes.tableCellBodyApproved]: row.reviewStatus === 'Approved',
+                              [classes.tableCellBodyDeclined]: row.reviewStatus === 'Declined',
+                              [classes.tableCellBodyAmended]: row.reviewStatus === 'Amended',
+                            }
+                          )}
+                          key={key}
+                        >
+                          {row[key]}
+                        </TableCell>
+                      ))
+                    }
+                  </TableRow>
+                ))
+            }
+            <TableRow>
+              <TablePagination
+                count={dataSet.length}
+                page={page}
+                rowsPerPage={rowsPerPage}
+                rowsPerPageOptions={[rowsPerPage]}
+                onChangePage={handleChangePage}
+              />
+            </TableRow>
+          </TableBody>
+        </Table>
+      </TableContainer>
+    </Paper>
+  );
+};
+
+// Needed to dynamically key in a DataRow
+interface DataField {
+  [key: string]: string | undefined;
+}
+
+export interface DataRow extends DataField {
+  region: string;
+  submittedBy?: string;
+  dateSubmitted: string;
+  dateReviewed?: string;
+  dateUpdated?: string;
+  reviewer?: string;
+  reviewStatus: string;
+}
+
+export default UpdateRequestTable;

--- a/components/modules/updates/UpdatesAdmin.tsx
+++ b/components/modules/updates/UpdatesAdmin.tsx
@@ -1,0 +1,62 @@
+import { makeStyles } from '@material-ui/core/styles';
+import { ReactElement } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import fixtureData from '../../../fixtures/updatesAdmin.json';
+import fixtureDataPending from '../../../fixtures/updatesAdminPending.json';
+import Typography from '../../base/Typography';
+import UpdateRequestTable from './UpdateRequestsTable';
+
+
+const useStyles = makeStyles(
+  (theme) => ({
+    root: {},
+    containerDataset: {
+      margin: `${theme.spacing(3)}px 0 ${theme.spacing(6)}px`,
+      '&:last-of-type': {
+        marginBottom: 0,
+      },
+    },
+    typographyH2: {
+      marginBottom: theme.spacing(3),
+      textAlign: 'center',
+    },
+  })
+);
+
+const UpdatesAdmin = (): ReactElement => {
+  const { t } = useTranslation('components');
+  const classes = useStyles();
+
+  return (
+    <div className={classes.root}>
+      <div className={classes.containerDataset}>
+        <Typography
+          className={classes.typographyH2}
+          variant="h2"
+        >
+          {t('updates-admin-heading-pending')}
+        </Typography>
+        <UpdateRequestTable
+          dataSet={fixtureDataPending}
+          admin
+        />
+      </div>
+
+      <div className={classes.containerDataset}>
+        <Typography
+          className={classes.typographyH2}
+          variant="h2"
+        >
+          {t('updates-admin-heading-reviewed')}
+        </Typography>
+        <UpdateRequestTable
+          dataSet={fixtureData}
+          admin
+        />
+      </div>
+    </div>
+  );
+};
+
+export default UpdatesAdmin;

--- a/components/modules/updates/UpdatesRegion.tsx
+++ b/components/modules/updates/UpdatesRegion.tsx
@@ -1,0 +1,40 @@
+import { makeStyles } from '@material-ui/core/styles';
+import { ReactElement } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import fixtureData from '../../../fixtures/updatesRegion.json';
+import Typography from '../../base/Typography';
+import UpdateRequestTable from './UpdateRequestsTable';
+
+const useStyles = makeStyles(
+  (theme) => ({
+    root: {
+      marginTop: theme.spacing(1),
+    },
+    typographyH2: {
+      marginBottom: theme.spacing(3),
+      textAlign: 'center',
+    },
+  })
+);
+
+const UpdatesRegion = (): ReactElement => {
+  const { t } = useTranslation('components');
+  const classes = useStyles();
+
+  return (
+    <div className={classes.root}>
+      <Typography
+        className={classes.typographyH2}
+        variant="h2"
+      >
+        {t('updates-region-heading')}
+      </Typography>
+      <UpdateRequestTable
+        dataSet={fixtureData}
+      />
+    </div>
+  );
+};
+
+export default UpdatesRegion;

--- a/fixtures/updatesAdmin.json
+++ b/fixtures/updatesAdmin.json
@@ -1,0 +1,82 @@
+[
+  {
+    "region": "St. John's",
+    "submittedBy": "Jane Smith",
+    "dateSubmitted": "February 5, 2021 3:19PM",
+    "dateReviewed": "February 12, 2021 3:45PM",
+    "reviewer": "Lesley Chard",
+    "reviewStatus": "Approved"
+  },
+  {
+    "region": "St. John's",
+    "submittedBy": "Jane Smith",
+    "dateSubmitted": "February 5, 2021 3:19PM",
+    "dateReviewed": "February 12, 2021 3:45PM",
+    "reviewer": "Lesley Chard",
+    "reviewStatus": "Declined"
+  },
+  {
+    "region": "St. John's",
+    "submittedBy": "Jane Smith",
+    "dateSubmitted": "February 5, 2021 3:19PM",
+    "dateReviewed": "February 12, 2021 3:45PM",
+    "reviewer": "Lesley Chard",
+    "reviewStatus": "Amended"
+  },
+  {
+    "region": "St. John's",
+    "submittedBy": "Jane Smith",
+    "dateSubmitted": "February 5, 2021 3:19PM",
+    "dateReviewed": "February 12, 2021 3:45PM",
+    "reviewer": "Lesley Chard",
+    "reviewStatus": "Approved"
+  },
+  {
+    "region": "St. John's",
+    "submittedBy": "Jane Smith",
+    "dateSubmitted": "February 5, 2021 3:19PM",
+    "dateReviewed": "February 12, 2021 3:45PM",
+    "reviewer": "Lesley Chard",
+    "reviewStatus": "Approved"
+  },
+  {
+    "region": "St. John's",
+    "submittedBy": "Jane Smith",
+    "dateSubmitted": "February 5, 2021 3:19PM",
+    "dateReviewed": "February 12, 2021 3:45PM",
+    "reviewer": "Lesley Chard",
+    "reviewStatus": "Approved"
+  },
+  {
+    "region": "St. John's",
+    "submittedBy": "Jane Smith",
+    "dateSubmitted": "February 5, 2021 3:19PM",
+    "dateReviewed": "February 12, 2021 3:45PM",
+    "reviewer": "Lesley Chard",
+    "reviewStatus": "Approved"
+  },
+  {
+    "region": "St. John's",
+    "submittedBy": "Jane Smith",
+    "dateSubmitted": "February 5, 2021 3:19PM",
+    "dateReviewed": "February 12, 2021 3:45PM",
+    "reviewer": "Lesley Chard",
+    "reviewStatus": "Approved"
+  },
+  {
+    "region": "Bay Bulls",
+    "submittedBy": "Jane Smith",
+    "dateSubmitted": "February 5, 2021 3:19PM",
+    "dateReviewed": "February 12, 2021 3:45PM",
+    "reviewer": "Lesley Chard",
+    "reviewStatus": "Approved"
+  },
+  {
+    "region": "Mount Pearl",
+    "submittedBy": "Jane Smith",
+    "dateSubmitted": "February 5, 2021 3:19PM",
+    "dateReviewed": "February 12, 2021 3:45PM",
+    "reviewer": "Lesley Chard",
+    "reviewStatus": "Approved"
+  }
+]

--- a/fixtures/updatesAdminPending.json
+++ b/fixtures/updatesAdminPending.json
@@ -1,0 +1,82 @@
+[
+  {
+    "region": "St. John's",
+    "submittedBy": "Jane Smith",
+    "dateSubmitted": "February 5, 2021 3:19PM",
+    "dateReviewed": "",
+    "reviewer": "",
+    "reviewStatus": ""
+  },
+  {
+    "region": "St. John's",
+    "submittedBy": "Jane Smith",
+    "dateSubmitted": "February 5, 2021 3:19PM",
+    "dateReviewed": "",
+    "reviewer": "",
+    "reviewStatus": ""
+  },
+  {
+    "region": "St. John's",
+    "submittedBy": "Jane Smith",
+    "dateSubmitted": "February 5, 2021 3:19PM",
+    "dateReviewed": "",
+    "reviewer": "",
+    "reviewStatus": ""
+  },
+  {
+    "region": "St. John's",
+    "submittedBy": "Jane Smith",
+    "dateSubmitted": "February 5, 2021 3:19PM",
+    "dateReviewed": "",
+    "reviewer": "",
+    "reviewStatus": ""
+  },
+  {
+    "region": "St. John's",
+    "submittedBy": "Jane Smith",
+    "dateSubmitted": "February 5, 2021 3:19PM",
+    "dateReviewed": "",
+    "reviewer": "",
+    "reviewStatus": ""
+  },
+  {
+    "region": "St. John's",
+    "submittedBy": "Jane Smith",
+    "dateSubmitted": "February 5, 2021 3:19PM",
+    "dateReviewed": "",
+    "reviewer": "",
+    "reviewStatus": ""
+  },
+  {
+    "region": "St. John's",
+    "submittedBy": "Jane Smith",
+    "dateSubmitted": "February 5, 2021 3:19PM",
+    "dateReviewed": "",
+    "reviewer": "",
+    "reviewStatus": ""
+  },
+  {
+    "region": "St. John's",
+    "submittedBy": "Jane Smith",
+    "dateSubmitted": "February 5, 2021 3:19PM",
+    "dateReviewed": "",
+    "reviewer": "",
+    "reviewStatus": ""
+  },
+  {
+    "region": "Bay Bulls",
+    "submittedBy": "Jane Smith",
+    "dateSubmitted": "February 5, 2021 3:19PM",
+    "dateReviewed": "",
+    "reviewer": "",
+    "reviewStatus": ""
+  },
+  {
+    "region": "Mount Pearl",
+    "submittedBy": "Jane Smith",
+    "dateSubmitted": "February 5, 2021 3:19PM",
+    "dateReviewed": "",
+    "reviewer": "",
+    "reviewStatus": ""
+  }
+]

--- a/fixtures/updatesRegion.json
+++ b/fixtures/updatesRegion.json
@@ -1,0 +1,50 @@
+[
+  {
+    "region": "St. John's",
+    "dateSubmitted": "February 5, 2021 3:19PM",
+    "dateUpdated": "",
+    "reviewStatus": "Pending"
+  },
+  {
+    "region": "St. John's",
+    "dateSubmitted": "February 5, 2021 3:19PM",
+    "dateUpdated": "",
+    "reviewStatus": "Pending"
+  },
+  {
+    "region": "St. John's",
+    "dateSubmitted": "February 5, 2021 3:19PM",
+    "dateUpdated": "",
+    "reviewStatus": "Pending"
+  },
+  {
+    "region": "St. John's",
+    "dateSubmitted": "February 5, 2021 3:19PM",
+    "dateUpdated": "February 12, 2021 3:45PM",
+    "reviewStatus": "In Progress"
+  },
+  {
+    "region": "St. John's",
+    "dateSubmitted": "February 5, 2021 3:19PM",
+    "dateUpdated": "February 12, 2021 3:45PM",
+    "reviewStatus": "Approved"
+  },
+  {
+    "region": "St. John's",
+    "dateSubmitted": "February 5, 2021 3:19PM",
+    "dateUpdated": "February 12, 2021 3:45PM",
+    "reviewStatus": "Approved"
+  },
+  {
+    "region": "St. John's",
+    "dateSubmitted": "February 5, 2021 3:19PM",
+    "dateUpdated": "February 12, 2021 3:45PM",
+    "reviewStatus": "Declined"
+  },
+  {
+    "region": "St. John's",
+    "dateSubmitted": "February 5, 2021 3:19PM",
+    "dateUpdated": "February 12, 2021 3:45PM",
+    "reviewStatus": "Amended"
+  }
+]

--- a/pages/updates.tsx
+++ b/pages/updates.tsx
@@ -1,0 +1,35 @@
+import { ReactElement } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useSelector } from 'react-redux';
+
+import AppLoading from '../components/base/AppLoading';
+import AdminLayout from '../components/layout/admin-layout/AdminLayout';
+import RegionLayout from '../components/layout/region-layout/RegionLayout';
+import UpdatesAdmin from '../components/modules/updates/UpdatesAdmin';
+import UpdatesRegion from '../components/modules/updates/UpdatesRegion';
+import { RootState } from '../store';
+
+const Updates = (): ReactElement => {
+  const { t } = useTranslation('pages');
+  const user = useSelector((state: RootState) => state.user);
+
+  if (user && user.role === 'admin') {
+    return (
+      <AdminLayout title={t('updates-title')}>
+        <UpdatesAdmin />
+      </AdminLayout>
+    );
+  }
+
+  if (user && user.role !== 'admin') {
+    return (
+      <RegionLayout title={t('updates-title')}>
+        <UpdatesRegion />
+      </RegionLayout>
+    );
+  }
+
+  return <AppLoading />;
+};
+
+export default Updates;

--- a/translations/en/_components.json
+++ b/translations/en/_components.json
@@ -20,6 +20,13 @@
   "businesses-table-remove-success": "You removed {{count}} business.",
   "businesses-table-remove-success_plural": "You removed {{count}} businesses.",
   "businesses-tour-button": "Show Businesses Tour",
+  "business-update-request-heading-date-reviewed": "Date Reviewed",
+  "business-update-request-heading-date-submitted": "Date Submitted",
+  "business-update-request-heading-date-updated": "Date Updated",
+  "business-update-request-heading-region": "Region",
+  "business-update-request-heading-review-status": "Review Status",
+  "business-update-request-heading-reviewer": "Reviewer",
+  "business-update-request-heading-submitted-by": "Submitted By",
   "data-sources-button": "Data Sources",
   "download-report-card-body": "We've compiled a booklet of comprehensive reports based on the data for your region.",
   "download-report-card-cta": "Download Report",
@@ -79,5 +86,8 @@
   "tour-next": "Next",
   "tour-skip": "Close",
   "user-menu-log-out": "Log Out",
-  "user-menu-profile": "Profile"
+  "user-menu-profile": "Profile",
+  "updates-admin-heading-pending": "Pending Update Requests",
+  "updates-admin-heading-reviewed": "Reviewed Update Requests",
+  "updates-region-heading": "Business Update Requests"
 }

--- a/translations/en/_pages.json
+++ b/translations/en/_pages.json
@@ -13,5 +13,6 @@
   "businesses-title": "Edit Businesses",
   "index-link-region-dashboard": "Region Dashboard",
   "profile-title": "Edit Profile",
-  "region-title": "Region Home"
+  "region-title": "Region Home",
+  "updates-title": "Business Update Requests"
 }


### PR DESCRIPTION
Closes #68 

Added route `/updates` for admin and region role users with a fixture data UI of their business update request tables.

![Screen Shot 2021-01-17 at 5 04 06 PM](https://user-images.githubusercontent.com/3619483/104855257-40ee1800-58e6-11eb-836c-42db6384af04.png)
![2021-01-17 17 05 11](https://user-images.githubusercontent.com/3619483/104855262-44819f00-58e6-11eb-9e90-de9907964227.gif)
