### PR TITLE
Region select is hooked into API

### DIFF
--- a/components/base/Auth0Redirect.tsx
+++ b/components/base/Auth0Redirect.tsx
@@ -4,7 +4,7 @@ import { useDispatch, useSelector } from 'react-redux';
 
 import AppLoading from '../../components/base/AppLoading';
 import { RootState } from '../../store';
-import { setToken } from '../../store/actions/auth0';
+import { setApiToken, setToken } from '../../store/actions/auth0';
 import { setUser } from '../../store/actions/user';
 
 type Props = {
@@ -29,8 +29,20 @@ const Auth0Redirect = ({ children }: Props): ReactElement => {
       dispatch(setToken(accessToken));
     }
     catch (e) {
-
       dispatch(setToken(e));
+    }
+  };
+
+  const getApiAccessToken = async () => {
+    try {
+      const accessToken = await getAccessTokenSilently({
+        domain: process.env.NEXT_PUBLIC_AUTHO_DOMAIN,
+        audience: process.env.NEXT_PUBLIC_AUTHO_API_AUDIENCE,
+      });
+      dispatch(setApiToken(accessToken));
+    }
+    catch (e) {
+      dispatch(setApiToken(e));
     }
   };
 
@@ -41,6 +53,7 @@ const Auth0Redirect = ({ children }: Props): ReactElement => {
   useEffect(() => {
     if (auth0.token !== null && user.profile === null && !user.loading && auth0User) {
       dispatch(setUser(auth0User.sub));
+      getApiAccessToken();
     }
   }, [auth0.token]);
 
@@ -53,6 +66,7 @@ const Auth0Redirect = ({ children }: Props): ReactElement => {
   if (
     isLoading
     || auth0.loading
+    || auth0.apiToken === null
     || auth0.token === null
     || user.id === null
   ) {
@@ -62,6 +76,7 @@ const Auth0Redirect = ({ children }: Props): ReactElement => {
   if (
     !isLoading
     && isAuthenticated
+    && auth0.apiToken !== null
     && auth0.token !== null
     && user.id !== null
   ) {

--- a/components/layout/RegionMenu.tsx
+++ b/components/layout/RegionMenu.tsx
@@ -150,8 +150,6 @@ const componentName = ({ type = 'region' }: Props): ReactElement => {
     }
   };
 
-  console.log('region', region);
-
   return (
     <FormControl fullWidth>
       <InputLabel

--- a/components/layout/region-layout/RegionSidebar.tsx
+++ b/components/layout/region-layout/RegionSidebar.tsx
@@ -8,11 +8,14 @@ import WorkIcon from '@material-ui/icons/Work';
 import Link from 'next/link';
 import { ReactElement } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useSelector } from  'react-redux';
 
 import Button from '../../base/Button';
 import Logo from '../../base/Logo';
 import TermsMenu from '../../base/TermsMenu';
+import Typography from '../../base/Typography';
 import RegionMenu from '../RegionMenu';
+import { RootState } from '../../../store';
 import { fade } from '../../../styles/helpers/color';
 import createShadow from '../../../styles/helpers/createShadow';
 import { fontSmoothOn } from '../../../styles/helpers/extend';
@@ -64,6 +67,10 @@ const useStyles = makeStyles(
         color: 'inherit',
       },
     },
+    typographyWarning: {
+      marginTop: theme.spacing(1),
+      textAlign: 'center',
+    },
     containerBottom: {
       bottom: 0,
       left: 0,
@@ -111,6 +118,7 @@ const useStyles = makeStyles(
 const RegionSidebar = (): ReactElement => {
   const { t } = useTranslation('components');
   const classes = useStyles();
+  const selectedRegion = useSelector((state: RootState) => state.region.selectedRegion);
 
   const handleDownloadReportClick = () => {
     window.open('/assets/fixture/test-report.pdf');
@@ -125,55 +133,75 @@ const RegionSidebar = (): ReactElement => {
         <RegionMenu />
       </div>
 
-      <MenuList className={classes.menuList}>
-        <MenuItem className={classes.menuItem}>
-          <Link href="/region">
-            <a
-              className={classes.listItemLink}
-              id="main-tour-step-nav-region-home"
+      {
+        selectedRegion
+          ? (
+            <MenuList className={classes.menuList}>
+              <MenuItem className={classes.menuItem}>
+                <Link href="/region">
+                  <a
+                    className={classes.listItemLink}
+                    id="main-tour-step-nav-region-home"
+                  >
+                    <ListItemIcon className={classes.listItemIcon}>
+                      <HomeIcon />
+                    </ListItemIcon>
+                    {t('region-sidebar-home')}
+                  </a>
+                </Link>
+              </MenuItem>
+              <MenuItem className={classes.menuItem}>
+                <Link href="/businesses">
+                  <a
+                    className={classes.listItemLink}
+                    id="main-tour-step-nav-businesses"
+                  >
+                    <ListItemIcon className={classes.listItemIcon}>
+                      <WorkIcon />
+                    </ListItemIcon>
+                    {t('region-sidebar-businesses')}
+                  </a>
+                </Link>
+              </MenuItem>
+            </MenuList>
+          )
+          : (
+            <Typography
+              className={classes.typographyWarning}
+              color="error"
+              variant="subtitle2"
             >
-              <ListItemIcon className={classes.listItemIcon}>
-                <HomeIcon />
-              </ListItemIcon>
-              {t('region-sidebar-home')}
-            </a>
-          </Link>
-        </MenuItem>
-        <MenuItem className={classes.menuItem}>
-          <Link href="/businesses">
-            <a
-              className={classes.listItemLink}
-              id="main-tour-step-nav-businesses"
-            >
-              <ListItemIcon className={classes.listItemIcon}>
-                <WorkIcon />
-              </ListItemIcon>
-              {t('region-sidebar-businesses')}
-            </a>
-          </Link>
-        </MenuItem>
-      </MenuList>
+              {t('region-sidebar-select-warning')}
+            </Typography>
+          )
+      }
 
       <div className={classes.containerBottom}>
-        <div className={classes.containerDownloadReport}>
-          <Button
-            className={classes.buttonDownloadReport}
-            component="a"
-            color="highlight"
-            fullWidth
-            endIcon={
-              <GetAppIcon
-                fontSize="small"
-              />
-            }
-            id="main-tour-step-sidebar-report"
-            onClick={handleDownloadReportClick}
-            variant="contained"
-            
-          >
-            {t('region-sidebar-download-report')}
-          </Button>
-        </div>
+        {
+          selectedRegion
+            ? (
+              <div className={classes.containerDownloadReport}>
+                <Button
+                  className={classes.buttonDownloadReport}
+                  component="a"
+                  color="highlight"
+                  fullWidth
+                  endIcon={
+                    <GetAppIcon
+                      fontSize="small"
+                    />
+                  }
+                  id="main-tour-step-sidebar-report"
+                  onClick={handleDownloadReportClick}
+                  variant="contained"
+                  
+                >
+                  {t('region-sidebar-download-report')}
+                </Button>
+              </div>
+            )
+            : null
+        }
         <div className={classes.containerTermsMenu}>
           <TermsMenu isMenu />
         </div>

--- a/next.config.js
+++ b/next.config.js
@@ -7,6 +7,7 @@ module.exports = withCSS({
     url: false,
   },
   env: {
+    NEXT_PUBLIC_AUTH0_API_AUDIENCE: 'https://ranlab-api-mvp-xxvyt3l5wa-nn.a.run.app',
     NEXT_PUBLIC_AUTH0_DOMAIN: 'lesleychard.auth0.com',
     NEXT_PUBLIC_AUTH0_CLIENT_ID: 'bnyMiWB15Rz5CwsxTNnrN9v5ftHcdabj',
     NEXT_PUBLIC_PRISMIC_REPO: 'ranlab', 

--- a/pages/businesses.tsx
+++ b/pages/businesses.tsx
@@ -16,6 +16,7 @@ import {
   useState,
 } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useSelector } from  'react-redux';
 
 import BusinessesDataSourcesDialog from '../components/modules/businesses/BusinessesDataSourcesDialog';
 import BusinessesFilters from '../components/modules/businesses/BusinessesFilters';
@@ -28,6 +29,7 @@ import RegionLayout from '../components/layout/region-layout/RegionLayout';
 import AlertDialog from '../components/base/AlertDialog';
 import BusinessesSaveSuccess from '../components/modules/businesses/BusinessesSaveSuccess';
 import BusinessesTourButton from '../components/modules/businesses/BusinessesTourButton';
+import { RootState } from '../store';
 
 const useStyles = makeStyles(
   (theme) => {
@@ -85,6 +87,7 @@ const useStyles = makeStyles(
 const Businesses = (): ReactElement => {
   const { t } = useTranslation('pages');
   const classes = useStyles();
+  const selectedRegion = useSelector((state: RootState) => state.region.selectedRegion);
 
   // Data Sources Dialog
 
@@ -218,7 +221,7 @@ const Businesses = (): ReactElement => {
               >
                 <Link href="/region">
                   <a className={classes.linkBreadcrumb}>
-                    St. John&rsquo;s
+                    {selectedRegion && selectedRegion.name}
                   </a>
                 </Link>
                 <Typography>

--- a/pages/region.tsx
+++ b/pages/region.tsx
@@ -2,11 +2,14 @@ import Grid from '@material-ui/core/Grid';
 import { makeStyles } from '@material-ui/core/styles';
 import { ReactElement } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useSelector } from  'react-redux';
 
 import RegionLayout from '../components/layout/region-layout/RegionLayout';
 import DownloadReportCard from '../components/modules/region-home/DownloadReportCard';
 import EditBusinessCard from '../components/modules/region-home/EditBusinessCard';
+import AppLoading from '../components/base/AppLoading';
 import Typography from '../components/base/Typography';
+import { RootState } from '../store';
 
 const useStyles = makeStyles(
   (theme) => ({
@@ -19,6 +22,12 @@ const useStyles = makeStyles(
         fontSize: '0.65em',
       },
     },
+    containerLoading: {
+      minHeight: '80vh',
+      display: 'flex',
+      justifyContent: 'center',
+      alignItems: 'center',
+    },
   }),
   { name: 'RanLabRegion' },
 );
@@ -26,29 +35,42 @@ const useStyles = makeStyles(
 const Region = (): ReactElement => {
   const { t } = useTranslation('pages');
   const classes = useStyles();
+  const selectedRegion = useSelector((state: RootState) => state.region.selectedRegion);
 
   return (
     <RegionLayout title={t('region-title')}>
-      <Typography
-        className={classes.typographyH1}
-        variant="h1"
-      >
-        <small>St. John&rsquo;s, NL</small>
-        {t('region-title')}
-      </Typography>
+      {
+        selectedRegion
+          ? (
+            <>
+              <Typography
+                className={classes.typographyH1}
+                variant="h1"
+              >
+                <small>{selectedRegion.name}</small>
+                {t('region-title')}
+              </Typography>
 
-      <Grid
-        alignItems="stretch"
-        container
-        spacing={3}
-      >
-        <Grid item sm={12} md={12} lg={7}>
-          <EditBusinessCard />
-        </Grid>
-        <Grid item sm={12} md={12} lg={5}>
-          <DownloadReportCard />
-        </Grid>
-      </Grid>
+              <Grid
+                alignItems="stretch"
+                container
+                spacing={3}
+              >
+                <Grid item sm={12} md={12} lg={7}>
+                  <EditBusinessCard />
+                </Grid>
+                <Grid item sm={12} md={12} lg={5}>
+                  <DownloadReportCard />
+                </Grid>
+              </Grid>
+            </>
+          )
+          : (
+            <div className={classes.containerLoading}>
+              <AppLoading />
+            </div>
+          )
+      }
     </RegionLayout>
   );
 };

--- a/pages/testing.tsx
+++ b/pages/testing.tsx
@@ -1,0 +1,169 @@
+import { useAuth0 } from '@auth0/auth0-react';
+import { Formik, Field, Form } from 'formik';
+import { TextField } from 'formik-material-ui';
+import Container from '@material-ui/core/Container';
+import { ReactElement } from 'react';
+import { useDispatch } from 'react-redux';
+
+import AdminLayout from '../components/layout/admin-layout/AdminLayout';
+import Button from '../components/base/Button';
+import { Business } from '../store/types/business';
+import { addBusinessByRegionId } from '../store/actions/business';
+import { addRegion } from '../store/actions/region';
+
+const testing = (): ReactElement => {
+  const { user } = useAuth0();
+  const dispatch = useDispatch();
+
+  const handleRegionSubmit = async ({
+    name,
+  }: {
+    name: string,
+  }) => {
+    const region = {
+      name,
+      manager: user.email,
+    };
+    dispatch(addRegion(region));
+  };
+
+  const handleBusinessSubmit = async ({
+    name,
+    year_added,
+    region,
+    employees,
+    latitude,
+    longitude,
+    industry,
+  }: {
+    name: string,
+    year_added: number,
+    region: string,
+    employees: number,
+    latitude: number,
+    longitude: number,
+    industry: string,
+  }) => {
+    const business: Business = {
+      name,
+      year_added,
+      region,
+      employees,
+      location: [latitude, longitude],
+      industry,
+    };
+    dispatch(addBusinessByRegionId(region, business));
+  };
+
+  return (
+    <AdminLayout>
+      <Container maxWidth="md">
+        <Formik
+          initialValues={{
+            name: '',
+          }}
+          onSubmit={handleRegionSubmit}
+        >
+          {({ submitForm }) => (
+            <Form>
+              <Field
+                component={TextField}
+                name="name"
+                label="Name"
+                fullWidth
+                required
+              />
+              <Button
+                color="primary"
+                onClick={submitForm}
+                variant="contained"
+              >
+                Add Test Region
+              </Button>
+            </Form>
+          )}
+        </Formik>
+
+        <Formik
+          initialValues={{
+            name: '',
+            year_added: 2021,
+            region: 'Mp8EdMS71uAz52NTpLK1',
+            employees: 100,
+            latitude: 47.50,
+            longitude: 52.30,
+            industry: 'Test Industry',
+          }}
+          onSubmit={handleBusinessSubmit}
+        >
+          {({ submitForm }) => (
+            <Form>
+              <Field
+                component={TextField}
+                name="name"
+                label="Name"
+                fullWidth
+                required
+              />
+              <Field
+                component={TextField}
+                name="year_added"
+                label="Year Added"
+                fullWidth
+                required
+                type="number"
+              />
+              <Field
+                component={TextField}
+                name="region"
+                label="Region ID"
+                fullWidth
+                required
+              />
+              <Field
+                component={TextField}
+                name="industry"
+                label="Industry"
+                fullWidth
+                required
+              />
+              <Field
+                component={TextField}
+                name="employees"
+                label="Employees"
+                fullWidth
+                required
+                type="number"
+              />
+              <Field
+                component={TextField}
+                name="latitude"
+                label="Latitude"
+                fullWidth
+                required
+                type="number"
+              />
+              <Field
+                component={TextField}
+                name="longitude"
+                label="Longitude"
+                fullWidth
+                required
+                type="number"
+              />
+              <Button
+                color="primary"
+                onClick={submitForm}
+                variant="contained"
+              >
+                Add Test Business
+              </Button>
+            </Form>
+          )}
+        </Formik>
+      </Container>
+    </AdminLayout>
+  );
+};
+
+export default testing;

--- a/store/actions/auth0.tsx
+++ b/store/actions/auth0.tsx
@@ -2,6 +2,9 @@ import {
   SET_TOKEN_SUCCESS,
   SET_TOKEN_STARTED,
   SET_TOKEN_FAILURE,
+  SET_API_TOKEN_SUCCESS,
+  SET_API_TOKEN_STARTED,
+  SET_API_TOKEN_FAILURE,
   Auth0ThunkResult,
   Auth0ThunkDispatch,
 } from '../types/auth0';
@@ -34,6 +37,39 @@ const setTokenSuccess = (token: string) => {
 
 const setTokenFailure = (error: Error) => ({
   type: SET_TOKEN_FAILURE,
+  payload: {
+    error,
+  },
+});
+
+export const setApiToken = (token: string | Error): Auth0ThunkResult => {
+  return async (dispatch: Auth0ThunkDispatch) => {
+    dispatch(setApiTokenStarted());
+
+    if (typeof token === 'string') {
+      dispatch(setApiTokenSuccess(token));
+    }
+    else {
+      dispatch(setApiTokenFailure(token));
+    }
+  };
+};
+
+const setApiTokenStarted = () => ({
+  type: SET_API_TOKEN_STARTED,
+});
+
+const setApiTokenSuccess = (apiToken: string) => {
+  return {
+    type: SET_API_TOKEN_SUCCESS,
+    payload: {
+      apiToken,
+    },
+  };
+};
+
+const setApiTokenFailure = (error: Error) => ({
+  type: SET_API_TOKEN_FAILURE,
   payload: {
     error,
   },

--- a/store/actions/business.tsx
+++ b/store/actions/business.tsx
@@ -1,0 +1,97 @@
+import { getHeaders } from '../helpers/headers';
+import {
+  ADD_BUSINESS_BY_REGION_ID_SUCCESS,
+  ADD_BUSINESS_BY_REGION_ID_STARTED,
+  ADD_BUSINESS_BY_REGION_ID_FAILURE,
+  FETCH_BUSINESSES_BY_REGION_ID_SUCCESS,
+  FETCH_BUSINESSES_BY_REGION_ID_STARTED,
+  FETCH_BUSINESSES_BY_REGION_ID_FAILURE,
+  Business,
+  BusinessThunkResult,
+  BusinessThunkDispatch,
+} from '../types/business';
+
+export const addBusinessByRegionId = (id: string, business: Business): BusinessThunkResult => {
+  return async (dispatch: BusinessThunkDispatch, getState) => {
+    dispatch(addBusinessByRegionIdStarted());
+    const { auth0 } = getState();
+    const api = `${process.env.NEXT_PUBLIC_AUTH0_API_AUDIENCE}/businesses`;
+    try {
+      const response = await fetch(api, {
+        method: 'POST',
+        headers: getHeaders(auth0.apiToken),
+        body: JSON.stringify(business),
+      });
+
+      const data = await response.json();
+      console.log('add business success', data);
+      dispatch(addBusinessByRegionIdSuccess(business, id));
+    }
+    catch (e) {
+      dispatch(addBusinessByRegionIdFailure(e));
+    }
+  };
+};
+
+const addBusinessByRegionIdStarted = () => ({
+  type: ADD_BUSINESS_BY_REGION_ID_STARTED,
+});
+
+const addBusinessByRegionIdSuccess = (business: Business, regionId: string) => {
+  return {
+    type: ADD_BUSINESS_BY_REGION_ID_SUCCESS,
+    payload: {
+      business,
+      regionId,
+    },
+  };
+};
+
+const addBusinessByRegionIdFailure = (error: Error) => ({
+  type: ADD_BUSINESS_BY_REGION_ID_FAILURE,
+  payload: {
+    error,
+  },
+});
+
+export const fetchBusinessesByRegionId = (id: number): BusinessThunkResult => {
+  return async (dispatch: BusinessThunkDispatch, getState) => {
+    dispatch(fetchBusinessesByRegionIdStarted());
+    const { auth0 } = getState();
+    const api = `${process.env.NEXT_PUBLIC_AUTH0_API_AUDIENCE}/regions/${id}/businesses`;
+    try {
+      const response = await fetch(api, {
+        method: 'GET',
+        headers: getHeaders(auth0.apiToken),
+      });
+
+      const data = await response.json();
+      dispatch(fetchBusinessesByRegionIdSuccess(data, id));
+      console.log(data);
+    }
+    catch (e) {
+      dispatch(fetchBusinessesByRegionIdFailure(e));
+    }
+  };
+};
+
+const fetchBusinessesByRegionIdStarted = () => ({
+  type: FETCH_BUSINESSES_BY_REGION_ID_STARTED,
+});
+
+const fetchBusinessesByRegionIdSuccess = (businesses: Business[], regionId: number) => {
+  return {
+    type: FETCH_BUSINESSES_BY_REGION_ID_SUCCESS,
+    payload: {
+      businesses,
+      regionId,
+    },
+  };
+};
+
+const fetchBusinessesByRegionIdFailure = (error: Error) => ({
+  type: FETCH_BUSINESSES_BY_REGION_ID_FAILURE,
+  payload: {
+    error,
+  },
+});

--- a/store/actions/region.tsx
+++ b/store/actions/region.tsx
@@ -1,0 +1,142 @@
+import { getHeaders } from '../helpers/headers';
+import {
+  ADD_REGION_SUCCESS,
+  ADD_REGION_STARTED,
+  ADD_REGION_FAILURE,
+  FETCH_REGIONS_SUCCESS,
+  FETCH_REGIONS_STARTED,
+  FETCH_REGIONS_FAILURE,
+  SET_SELECTED_REGION_SUCCESS,
+  SET_SELECTED_REGION_STARTED,
+  SET_SELECTED_REGION_FAILURE,
+  Region,
+  RegionThunkResult,
+  RegionThunkDispatch,
+} from '../types/region';
+
+export const addRegion = (
+  { name, manager }: 
+  { name: string, manager: string }
+): RegionThunkResult => {
+  return async (dispatch: RegionThunkDispatch, getState) => {
+    dispatch(addRegionStarted());
+    const { auth0 } = getState();
+    const api = `${process.env.NEXT_PUBLIC_AUTH0_API_AUDIENCE}/regions`;
+    try {
+      const response = await fetch(api, {
+        method: 'POST',
+        headers: getHeaders(auth0.apiToken),
+        body: JSON.stringify({ name, manager }),
+      });
+
+      const data = await response.json();
+      dispatch(addRegionSuccess({ name, manager, id: data.regionId }));
+    }
+    catch (e) {
+      dispatch(addRegionFailure(e));
+    }
+  };
+};
+
+const addRegionStarted = () => ({
+  type: ADD_REGION_STARTED,
+});
+
+const addRegionSuccess = (region: Region) => {
+  return {
+    type: ADD_REGION_SUCCESS,
+    payload: {
+      region,
+    },
+  };
+};
+
+const addRegionFailure = (error: Error) => ({
+  type: ADD_REGION_FAILURE,
+  payload: {
+    error,
+  },
+});
+
+export const fetchRegions = (userId: string): RegionThunkResult => {
+  return async (dispatch: RegionThunkDispatch, getState) => {
+    dispatch(fetchRegionsStarted());
+    const { auth0 } = getState();
+    const api = `${process.env.NEXT_PUBLIC_AUTH0_API_AUDIENCE}/regions/manager/${userId}`;
+    try {
+      const response = await fetch(api, {
+        method: 'GET',
+        headers: getHeaders(auth0.apiToken),
+      });
+
+      const data = await response.json();
+      dispatch(fetchRegionsSuccess(data.regions));
+    }
+    catch (e) {
+      dispatch(fetchRegionsFailure(e));
+    }
+  };
+};
+
+const fetchRegionsStarted = () => ({
+  type: FETCH_REGIONS_STARTED,
+});
+
+const fetchRegionsSuccess = (regions: Region[]) => {
+  return {
+    type: FETCH_REGIONS_SUCCESS,
+    payload: {
+      regions,
+    },
+  };
+};
+
+const fetchRegionsFailure = (error: Error) => ({
+  type: FETCH_REGIONS_FAILURE,
+  payload: {
+    error,
+  },
+});
+
+export const setSelectedRegion = (selectedRegion: Region): RegionThunkResult => {
+  return async (dispatch: RegionThunkDispatch, getState) => {
+    dispatch(setSelectedRegionStarted());
+    const { region: regionState } = getState();
+
+    if (regionState.regions) {
+      const validRegion = regionState.regions.filter((region: Region) => {
+        return region.id === selectedRegion.id;
+      });
+
+      if (validRegion.length) {
+        dispatch(setSelectedRegionSuccess(selectedRegion));
+      }
+      else {
+        dispatch(setSelectedRegionFailure(new Error('Selected region does not exist.')));
+      }
+    }
+    else {
+      dispatch(setSelectedRegionFailure(new Error('User-managed regions unknown.')));
+    }
+  };
+};
+
+const setSelectedRegionStarted = () => ({
+  type: SET_SELECTED_REGION_STARTED,
+});
+
+const setSelectedRegionSuccess = (selectedRegion: Region) => {
+  return {
+    type: SET_SELECTED_REGION_SUCCESS,
+    payload: {
+      selectedRegion,
+    },
+  };
+};
+
+const setSelectedRegionFailure = (error: Error) => ({
+  type: SET_SELECTED_REGION_FAILURE,
+  payload: {
+    error,
+  },
+});

--- a/store/actions/user.tsx
+++ b/store/actions/user.tsx
@@ -29,8 +29,9 @@ export const setUser = (userId: string): UserThunkResult => {
 
         const userProfile = user_metadata || null;
         const userRole = app_metadata && app_metadata.role ? app_metadata.role : 'region';
+        const regionIds = app_metadata && app_metadata.manages ? app_metadata.manages : [];
 
-        dispatch(setUserSuccess(userId, userProfile, userRole));
+        dispatch(setUserSuccess(userId, userProfile, userRole, regionIds));
       }
       catch (e) {
         dispatch(setUserFailure(e));
@@ -47,12 +48,13 @@ const setUserStarted = () => ({
   type: SET_USER_STARTED,
 });
 
-const setUserSuccess = (id: string, profile: UserProfile, role: UserRole) => ({
+const setUserSuccess = (id: string, profile: UserProfile, role: UserRole, regionIds: number[]) => ({
   type: SET_USER_SUCCESS,
   payload: {
     id,
     role,
     profile,
+    regionIds,
   },
 });
 

--- a/store/helpers/business.tsx
+++ b/store/helpers/business.tsx
@@ -1,0 +1,26 @@
+import {
+  RegionBusiness,
+  Business,
+} from '../types/business';
+
+/**
+ * Appends the new business to the previous region
+ * or creates a new region instance for the business
+ * @param prevBusinesses Previous list of region businesses
+ * @param regionId Region ID of new business
+ * @param newBusiness New business data
+ */
+export const getNewBusinesses = (
+  prevBusinesses: RegionBusiness,
+  regionId: string,
+  newBusiness: Business
+): RegionBusiness => {
+  const newBusinesses: RegionBusiness = prevBusinesses;
+  if (prevBusinesses[regionId]) {
+    newBusinesses[regionId].push(newBusiness);
+  }
+  else {
+    newBusinesses[regionId] = [newBusiness];
+  }
+  return newBusinesses;
+};

--- a/store/helpers/headers.tsx
+++ b/store/helpers/headers.tsx
@@ -1,0 +1,11 @@
+/**
+ * Generated headers for an internal API request
+ * @param token api auth token
+ */
+export const getHeaders = (token: string | null | undefined): Headers => {
+  return new Headers({
+    Accept: 'application/json',
+    Authorization: `Bearer ${token}`,
+    'Content-Type': 'application/json',
+  });
+};

--- a/store/helpers/region.tsx
+++ b/store/helpers/region.tsx
@@ -1,0 +1,21 @@
+import { Region } from '../types/region';
+
+/**
+ * Appends the new region to the list of previous regions
+ * if not already part of the array
+ * @param prevRegions Previous list of regions from state
+ * @param newRegion New region to be appended or skipped
+ */
+export const getNewRegions = (
+  prevRegions: Region[],
+  newRegion: Region,
+): Region[] => {
+  const newRegions = prevRegions;
+  const existingRegion = prevRegions.filter(region => {
+    return region.id === newRegion.id;
+  });
+  if (!existingRegion.length) {
+    newRegions.push(newRegion);
+  }
+  return newRegions;
+};

--- a/store/reducers/auth0.tsx
+++ b/store/reducers/auth0.tsx
@@ -2,11 +2,15 @@ import {
   SET_TOKEN_SUCCESS,
   SET_TOKEN_STARTED,
   SET_TOKEN_FAILURE,
+  SET_API_TOKEN_SUCCESS,
+  SET_API_TOKEN_STARTED,
+  SET_API_TOKEN_FAILURE,
   Auth0ActionTypes,
   Auth0State,
 } from '../types/auth0';
 
 const initialState: Auth0State = {
+  apiToken: null,
   error: null,
   loading: false,
   token: null,
@@ -27,6 +31,24 @@ const auth0Reducer = (state = initialState, action: Auth0ActionTypes): Auth0Stat
         token: action.payload.token,
       };
     case SET_TOKEN_FAILURE:
+      return {
+        ...state,
+        loading: false,
+        error: action.payload.error,
+      };
+    case SET_API_TOKEN_STARTED:
+      return {
+        ...state,
+        loading: true,
+      };
+    case SET_API_TOKEN_SUCCESS:
+      return {
+        ...state,
+        loading: false,
+        error: null,
+        apiToken: action.payload.apiToken,
+      };
+    case SET_API_TOKEN_FAILURE:
       return {
         ...state,
         loading: false,

--- a/store/reducers/business.tsx
+++ b/store/reducers/business.tsx
@@ -1,0 +1,73 @@
+import { getNewBusinesses } from '../helpers/business';
+import {
+  ADD_BUSINESS_BY_REGION_ID_SUCCESS,
+  ADD_BUSINESS_BY_REGION_ID_STARTED,
+  ADD_BUSINESS_BY_REGION_ID_FAILURE,
+  FETCH_BUSINESSES_BY_REGION_ID_SUCCESS,
+  FETCH_BUSINESSES_BY_REGION_ID_STARTED,
+  FETCH_BUSINESSES_BY_REGION_ID_FAILURE,
+  BusinessActionTypes,
+  BusinessState,
+} from '../types/business';
+
+const initialState: BusinessState = {
+  error: null,
+  loading: false,
+  businesses: {},
+};
+
+const businessReducer = (
+  state = initialState,
+  action: BusinessActionTypes
+): BusinessState => {
+  const prevBusinesses = state.businesses ? state.businesses : {};
+  switch (action.type) {
+    case ADD_BUSINESS_BY_REGION_ID_STARTED:
+      return {
+        ...state,
+        loading: true,
+      };
+    case ADD_BUSINESS_BY_REGION_ID_SUCCESS:
+      return {
+        ...state,
+        loading: false,
+        error: null,
+        businesses: getNewBusinesses(
+          prevBusinesses,
+          action.payload.regionId,
+          action.payload.business,
+        ),
+      };
+    case ADD_BUSINESS_BY_REGION_ID_FAILURE:
+      return {
+        ...state,
+        loading: false,
+        error: action.payload.error,
+      };
+    case FETCH_BUSINESSES_BY_REGION_ID_STARTED:
+      return {
+        ...state,
+        loading: true,
+      };
+    case FETCH_BUSINESSES_BY_REGION_ID_SUCCESS:
+      return {
+        ...state,
+        loading: false,
+        error: null,
+        businesses: {
+          ...prevBusinesses,
+          [action.payload.regionId]: action.payload.businesses,
+        },
+      };
+    case FETCH_BUSINESSES_BY_REGION_ID_FAILURE:
+      return {
+        ...state,
+        loading: false,
+        error: action.payload.error,
+      };
+    default:
+      return state;
+  }
+};
+
+export default businessReducer;

--- a/store/reducers/region.tsx
+++ b/store/reducers/region.tsx
@@ -1,0 +1,92 @@
+import { getNewRegions } from '../helpers/region';
+import {
+  ADD_REGION_SUCCESS,
+  ADD_REGION_STARTED,
+  ADD_REGION_FAILURE,
+  FETCH_REGIONS_SUCCESS,
+  FETCH_REGIONS_STARTED,
+  FETCH_REGIONS_FAILURE,
+  SET_SELECTED_REGION_SUCCESS,
+  SET_SELECTED_REGION_STARTED,
+  SET_SELECTED_REGION_FAILURE,
+  RegionActionTypes,
+  RegionState,
+} from '../types/region';
+
+const initialState: RegionState = {
+  error: null,
+  loading: false,
+};
+
+const regionReducer = (
+  state = initialState,
+  action: RegionActionTypes
+): RegionState => {
+  const prevRegions = state.regions ? state.regions : [];
+  switch (action.type) {
+    case ADD_REGION_STARTED:
+      return {
+        ...state,
+        loading: true,
+      };
+    case ADD_REGION_SUCCESS:
+      return {
+        ...state,
+        loading: false,
+        error: null,
+        regions: getNewRegions(
+          prevRegions,
+          action.payload.region,
+        ),
+      };
+    case ADD_REGION_FAILURE:
+      return {
+        ...state,
+        loading: false,
+        error: action.payload.error,
+      };
+    case FETCH_REGIONS_STARTED:
+      return {
+        ...state,
+        loading: true,
+      };
+    case FETCH_REGIONS_SUCCESS:
+      return {
+        ...state,
+        loading: false,
+        error: null,
+        regions: [
+          ...prevRegions,
+          ...action.payload.regions,
+        ],
+      };
+    case FETCH_REGIONS_FAILURE:
+      return {
+        ...state,
+        loading: false,
+        error: action.payload.error,
+      };
+    case SET_SELECTED_REGION_STARTED:
+      return {
+        ...state,
+        loading: true,
+      };
+    case SET_SELECTED_REGION_SUCCESS:
+      return {
+        ...state,
+        loading: false,
+        error: null,
+        selectedRegion: action.payload.selectedRegion,
+      };
+    case SET_SELECTED_REGION_FAILURE:
+      return {
+        ...state,
+        loading: false,
+        error: action.payload.error,
+      };
+    default:
+      return state;
+  }
+};
+
+export default regionReducer;

--- a/store/reducers/root.tsx
+++ b/store/reducers/root.tsx
@@ -3,25 +3,33 @@ import { combineReducers, AnyAction } from 'redux';
 
 import {
   Auth0State,
+  BusinessState,
   InfoDialogState,
+  RegionState,
   TourState,
   UserState,
 } from '../types';
 import auth0 from './auth0';
+import business from './business';
 import infoDialog from './infoDialog';
+import region from './region';
 import tour from './tour';
 import user from './user';
 
 const combinedReducer = combineReducers({
   auth0,
+  business,
   infoDialog,
+  region,
   tour,
   user,
 });
 
 export type RootState = {
   auth0: Auth0State,
+  business: BusinessState,
   infoDialog: InfoDialogState,
+  region: RegionState,
   tour: TourState,
   user: UserState,
 };

--- a/store/reducers/user.tsx
+++ b/store/reducers/user.tsx
@@ -15,6 +15,7 @@ const initialState: UserState = {
   id: null,
   role: null,
   profile: null,
+  regionIds: [],
 };
 
 const userReducer = (state = initialState, action: UserActionTypes): UserState => {
@@ -32,6 +33,7 @@ const userReducer = (state = initialState, action: UserActionTypes): UserState =
         id: action.payload.id,
         role: action.payload.role,
         profile: action.payload.profile,
+        regionIds: action.payload.regionIds,
       };
     case SET_USER_FAILURE:
       return {

--- a/store/types/auth0.tsx
+++ b/store/types/auth0.tsx
@@ -6,6 +6,10 @@ export const SET_TOKEN_STARTED = 'SET_TOKEN_STARTED';
 export const SET_TOKEN_SUCCESS = 'SET_TOKEN_SUCCESS';
 export const SET_TOKEN_FAILURE = 'SET_TOKEN_FAILURE';
 
+export const SET_API_TOKEN_STARTED = 'SET_API_TOKEN_STARTED';
+export const SET_API_TOKEN_SUCCESS = 'SET_API_TOKEN_SUCCESS';
+export const SET_API_TOKEN_FAILURE = 'SET_API_TOKEN_FAILURE';
+
 interface SetTokenStartedAction {
   type: typeof SET_TOKEN_STARTED;
 }
@@ -24,16 +28,38 @@ interface SetTokenFailureAction {
   };
 }
 
+interface SetApiTokenStartedAction {
+  type: typeof SET_API_TOKEN_STARTED;
+}
+
+interface SetApiTokenSuccessAction {
+  type: typeof SET_API_TOKEN_SUCCESS;
+  payload: {
+    apiToken: string,
+  };
+}
+
+interface SetApiTokenFailureAction {
+  type: typeof SET_API_TOKEN_FAILURE;
+  payload: {
+    error: Error,
+  };
+}
+
 export type Auth0ActionTypes =
   SetTokenStartedAction
   | SetTokenSuccessAction
-  | SetTokenFailureAction;
+  | SetTokenFailureAction
+  | SetApiTokenStartedAction
+  | SetApiTokenSuccessAction
+  | SetApiTokenFailureAction;
 
 export type Auth0ThunkResult = ThunkAction<void, RootState, undefined, Auth0ActionTypes>;
 
 export type Auth0ThunkDispatch = ThunkDispatch<RootState, void, Action>;
 
 export interface Auth0State {
+  apiToken?: string | null;
   error?: Error | null;
   loading: boolean;
   token?: string | null;

--- a/store/types/business.tsx
+++ b/store/types/business.tsx
@@ -1,0 +1,81 @@
+import { Action } from 'redux';
+import { ThunkDispatch, ThunkAction } from 'redux-thunk';
+
+import { RootState } from '../reducers/root';
+
+export const ADD_BUSINESS_BY_REGION_ID_STARTED = 'ADD_BUSINESS_BY_REGION_ID_STARTED';
+export const ADD_BUSINESS_BY_REGION_ID_SUCCESS = 'ADD_BUSINESS_BY_REGION_ID_SUCCESS';
+export const ADD_BUSINESS_BY_REGION_ID_FAILURE = 'ADD_BUSINESS_BY_REGION_ID_FAILURE';
+
+export const FETCH_BUSINESSES_BY_REGION_ID_STARTED = 'FETCH_BUSINESSES_BY_REGION_ID_STARTED';
+export const FETCH_BUSINESSES_BY_REGION_ID_SUCCESS = 'FETCH_BUSINESSES_BY_REGION_ID_SUCCESS';
+export const FETCH_BUSINESSES_BY_REGION_ID_FAILURE = 'FETCH_BUSINESSES_BY_REGION_ID_FAILURE';
+
+interface AddBusinessByRegionIdStartedAction {
+  type: typeof ADD_BUSINESS_BY_REGION_ID_STARTED;
+}
+
+interface AddBusinessByRegionIdSuccessAction {
+  type: typeof ADD_BUSINESS_BY_REGION_ID_SUCCESS;
+  payload: {
+    business: Business,
+    regionId: string,
+  };
+}
+
+interface AddBusinessByRegionIdFailureAction {
+  type: typeof ADD_BUSINESS_BY_REGION_ID_FAILURE;
+  payload: {
+    error: Error,
+  };
+}
+
+interface FetchBusinessesByRegionIdStartedAction {
+  type: typeof FETCH_BUSINESSES_BY_REGION_ID_STARTED;
+}
+
+interface FetchBusinessesByRegionIdSuccessAction {
+  type: typeof FETCH_BUSINESSES_BY_REGION_ID_SUCCESS;
+  payload: {
+    businesses: Business[],
+    regionId: string,
+  };
+}
+
+interface FetchBusinessesByRegionIdFailureAction {
+  type: typeof FETCH_BUSINESSES_BY_REGION_ID_FAILURE;
+  payload: {
+    error: Error,
+  };
+}
+
+export type BusinessActionTypes =
+  AddBusinessByRegionIdStartedAction
+  | AddBusinessByRegionIdSuccessAction
+  | AddBusinessByRegionIdFailureAction
+  | FetchBusinessesByRegionIdStartedAction
+  | FetchBusinessesByRegionIdSuccessAction
+  | FetchBusinessesByRegionIdFailureAction;
+
+export type BusinessThunkResult = ThunkAction<void, RootState, undefined, BusinessActionTypes>;
+
+export type BusinessThunkDispatch = ThunkDispatch<RootState, void, Action>;
+
+export interface BusinessState {
+  error?: Error | null;
+  loading: boolean;
+  businesses?: RegionBusiness | null;
+}
+
+export interface Business {
+  name: string;
+  year_added: number;
+  region: string;
+  employees: number;
+  industry: string;
+  location: number[];
+}
+
+export interface RegionBusiness {
+  [regionId: string]: Business[];
+}

--- a/store/types/index.tsx
+++ b/store/types/index.tsx
@@ -1,4 +1,6 @@
 export type { Auth0State } from './auth0';
+export type { BusinessState } from './business';
 export type { InfoDialogState } from './infoDialog';
+export type { RegionState } from './region';
 export type { TourState } from './tour';
 export type { UserState } from './user';

--- a/store/types/region.tsx
+++ b/store/types/region.tsx
@@ -1,0 +1,98 @@
+import { Action } from 'redux';
+import { ThunkDispatch, ThunkAction } from 'redux-thunk';
+
+import { RootState } from '../reducers/root';
+
+export const ADD_REGION_STARTED = 'ADD_REGION_STARTED';
+export const ADD_REGION_SUCCESS = 'ADD_REGION_SUCCESS';
+export const ADD_REGION_FAILURE = 'ADD_REGION_FAILURE';
+
+export const FETCH_REGIONS_STARTED = 'FETCH_REGIONS_STARTED';
+export const FETCH_REGIONS_SUCCESS = 'FETCH_REGIONS_SUCCESS';
+export const FETCH_REGIONS_FAILURE = 'FETCH_REGIONS_FAILURE';
+
+export const SET_SELECTED_REGION_STARTED = 'SET_SELECTED_REGION_STARTED';
+export const SET_SELECTED_REGION_SUCCESS = 'SET_SELECTED_REGION_SUCCESS';
+export const SET_SELECTED_REGION_FAILURE = 'SET_SELECTED_REGION_FAILURE';
+
+interface AddRegionStartedAction {
+  type: typeof ADD_REGION_STARTED;
+}
+
+interface AddRegionSuccessAction {
+  type: typeof ADD_REGION_SUCCESS;
+  payload: {
+    region: Region,
+  };
+}
+
+interface AddRegionFailureAction {
+  type: typeof ADD_REGION_FAILURE;
+  payload: {
+    error: Error,
+  };
+}
+
+interface FetchRegionsStartedAction {
+  type: typeof FETCH_REGIONS_STARTED;
+}
+
+interface FetchRegionsSuccessAction {
+  type: typeof FETCH_REGIONS_SUCCESS;
+  payload: {
+    regions: Region[],
+  };
+}
+
+interface FetchRegionsFailureAction {
+  type: typeof FETCH_REGIONS_FAILURE;
+  payload: {
+    error: Error,
+  };
+}
+
+interface SetSelectedRegionStartedAction {
+  type: typeof SET_SELECTED_REGION_STARTED;
+}
+
+interface SetSelectedRegionSuccessAction {
+  type: typeof SET_SELECTED_REGION_SUCCESS;
+  payload: {
+    selectedRegion: Region,
+  };
+}
+
+interface SetSelectedRegionFailureAction {
+  type: typeof SET_SELECTED_REGION_FAILURE;
+  payload: {
+    error: Error,
+  };
+}
+
+export type RegionActionTypes =
+  AddRegionStartedAction
+  | AddRegionSuccessAction
+  | AddRegionFailureAction
+  | FetchRegionsStartedAction
+  | FetchRegionsSuccessAction
+  | FetchRegionsFailureAction
+  | SetSelectedRegionStartedAction
+  | SetSelectedRegionSuccessAction
+  | SetSelectedRegionFailureAction;
+
+export type RegionThunkResult = ThunkAction<void, RootState, undefined, RegionActionTypes>;
+
+export type RegionThunkDispatch = ThunkDispatch<RootState, void, Action>;
+
+export interface RegionState {
+  error?: Error | null;
+  loading: boolean;
+  regions?: Region[];
+  selectedRegion?: Region;
+}
+
+export interface Region {
+  id: string;
+  name: string;
+  manager: string;
+}

--- a/store/types/user.tsx
+++ b/store/types/user.tsx
@@ -34,6 +34,7 @@ interface SetUserSuccessAction {
     id: string,
     role: UserRole,
     profile: UserProfile,
+    regionIds: number[],
   };
 }
 
@@ -80,5 +81,6 @@ export interface UserState {
   id?: string | null;
   role?: UserRole | null;
   profile?: UserProfile | null;
+  regionIds?: number[] | null;
 }
 

--- a/translations/en/_components.json
+++ b/translations/en/_components.json
@@ -77,6 +77,7 @@
   "region-sidebar-contact": "Contact",
   "region-sidebar-download-report": "Download Report",
   "region-sidebar-home": "Region Home",
+  "region-sidebar-select-warning": "You must select a region from the above menu.",
   "region-sidebar-terms": "Terms",
   "region-toolbar-toggle-button-label": "Toggle Menu",
   "region-walkthrough-button": "Show Walkthrough",


### PR DESCRIPTION
Resolves #62

- Added call to get **opaque** API token from Auth0 to send to backend for authentication
- Region select populates menu with current users managed regions 
- Region can be selected and is displayed throughout pages
-  Added testing forms for adding regions/businesses
- Groundwork laid for adding businesses

